### PR TITLE
Remove unnecessary semicolon

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Transports/Ses.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Transports/Ses.php
@@ -27,7 +27,7 @@ class Aschroder_SMTPPro_Model_Transports_Ses {
                 'accessKey' => $_helper->getAmazonSESAccessKey($storeId),
                 'privateKey' => $_helper->getAmazonSESPrivateKey($storeId)
             ),
-            $_helper->getAmazonSESEndpoint($storeId);
+            $_helper->getAmazonSESEndpoint($storeId)
         );
 
         return $emailTransport;


### PR DESCRIPTION
Semicolon will make fatal error, because value here is parameter of App_Mail_Transport_AmazonSES constructor.